### PR TITLE
Refine presentation bindings and pagination

### DIFF
--- a/Presentation/Adapters/TransactionAdapter.cs
+++ b/Presentation/Adapters/TransactionAdapter.cs
@@ -5,6 +5,7 @@ using MoneyTracker.Application.DTOs;
 using MoneyTracker.Core.Enums;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MoneyTracker.Presentation.Adapters
 {
@@ -25,9 +26,9 @@ namespace MoneyTracker.Presentation.Adapters
         /// <summary>
         /// Actualiza la lista de transacciones
         /// </summary>
-        public void UpdateTransactions(List<TransactionDto> transactions)
+        public void UpdateTransactions(IEnumerable<TransactionDto> transactions)
         {
-            _transactions = transactions ?? new List<TransactionDto>();
+            _transactions = transactions?.ToList() ?? new List<TransactionDto>();
             NotifyDataSetChanged();
         }
 

--- a/Presentation/Extensions/AtomicReference.cs
+++ b/Presentation/Extensions/AtomicReference.cs
@@ -1,36 +1,37 @@
-﻿
-    public class AtomicReference<T> where T : class
+﻿namespace MoneyTracker.Presentation.Extensions;
+
+public class AtomicReference<T> where T : class
+{
+    private volatile T? _value;
+    private readonly object _lock = new();
+
+    public AtomicReference() { }
+
+    public AtomicReference(T? initialValue)
     {
-        private volatile T? _value;
-        private readonly object _lock = new();
+        _value = initialValue;
+    }
 
-        public AtomicReference() { }
-
-        public AtomicReference(T? initialValue)
+    public T? GetAndSet(T? newValue)
+    {
+        lock (_lock)
         {
-            _value = initialValue;
-        }
-
-        public T? GetAndSet(T? newValue)
-        {
-            lock (_lock)
-            {
-                var old = _value;
-                _value = newValue;
-                return old;
-            }
-        }
-
-        public void Set(T? newValue)
-        {
-            lock (_lock)
-            {
-                _value = newValue;
-            }
-        }
-
-        public T? Get()
-        {
-            return _value;
+            var old = _value;
+            _value = newValue;
+            return old;
         }
     }
+
+    public void Set(T? newValue)
+    {
+        lock (_lock)
+        {
+            _value = newValue;
+        }
+    }
+
+    public T? Get()
+    {
+        return _value;
+    }
+}

--- a/Presentation/Extensions/ThreadSafeBindingExtensions.cs
+++ b/Presentation/Extensions/ThreadSafeBindingExtensions.cs
@@ -1,10 +1,11 @@
 ﻿using Android.OS;
+using Android.Widget;
 using CommunityToolkit.Mvvm.ComponentModel;
-using MoneyTracker.Presentation.Extensions;
+using System;
 using System.ComponentModel;
 using System.Linq.Expressions;
-using MoneyTracker.Presentation.ViewModels;
 
+namespace MoneyTracker.Presentation.Extensions;
 
 public static partial class ThreadSafeBindingExtensions
 {

--- a/Presentation/Fragments/AddTransactionFragment.cs
+++ b/Presentation/Fragments/AddTransactionFragment.cs
@@ -4,9 +4,13 @@ using Android.Widget;
 using AndroidX.Fragment.App;
 using MoneyTracker.Application.DTOs;
 using MoneyTracker.Core.Enums;
+using MoneyTracker.Presentation.Extensions;
 using MoneyTracker.Presentation.ViewModels;
 using Google.Android.Material.TextField;
 using System;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Linq;
 using AndroidX.AppCompat.App;
 using Fragment = AndroidX.Fragment.App.Fragment;
 
@@ -18,6 +22,9 @@ namespace MoneyTracker.Presentation.Fragments
     public class AddTransactionFragment : Fragment
     {
         private AddTransactionViewModel? _viewModel;
+        private CompositeDisposable? _bindings;
+        private CompositeDisposable? _viewModelSubscriptions;
+        private CompositeDisposable? _uiEventSubscriptions;
 
         // Controles del formulario
         private TextInputLayout? _descriptionInputLayout;
@@ -38,6 +45,7 @@ namespace MoneyTracker.Presentation.Fragments
         private Button? _saveButton;
         private Button? _cancelButton;
         private LinearLayout? _validationErrorsLayout;
+        private EventHandler<AdapterView.ItemSelectedEventArgs>? _categorySelectedHandler;
 
         /// <summary>
         /// Crea una nueva instancia para editar una transacción
@@ -104,97 +112,135 @@ namespace MoneyTracker.Presentation.Fragments
         /// </summary>
         private void SetupEventHandlers()
         {
-            // Botones principales
+            _uiEventSubscriptions?.Dispose();
+            _uiEventSubscriptions = new CompositeDisposable();
+
             if (_saveButton != null)
-                _saveButton.Click += (s, e) => _viewModel?.SaveTransactionCommand.Execute(null);
+            {
+                EventHandler handler = (s, e) => _viewModel?.SaveTransactionCommand.Execute(null);
+                _saveButton.Click += handler;
+                _uiEventSubscriptions.Add(new ActionDisposable(() => _saveButton.Click -= handler));
+            }
 
             if (_cancelButton != null)
-                _cancelButton.Click += (s, e) => _viewModel?.CancelCommand.Execute(null);
-
-            // Campos de texto
-            if (_descriptionEditText != null)
             {
-                _descriptionEditText.TextChanged += (s, e) =>
-                {
-                    if (_viewModel != null)
-                        _viewModel.Description = e?.Text?.ToString() ?? string.Empty;
-                };
+                EventHandler handler = (s, e) => _viewModel?.CancelCommand.Execute(null);
+                _cancelButton.Click += handler;
+                _uiEventSubscriptions.Add(new ActionDisposable(() => _cancelButton.Click -= handler));
             }
 
-            if (_amountEditText != null)
-            {
-                _amountEditText.TextChanged += (s, e) =>
-                {
-                    if (_viewModel != null && decimal.TryParse(e?.Text?.ToString(), out var amount))
-                        _viewModel.Amount = amount;
-                };
-            }
-
-            // RadioButtons para tipo de transacción
             if (_incomeChip != null)
             {
-                _incomeChip.CheckedChange += (s, e) =>
+                EventHandler<CompoundButton.CheckedChangeEventArgs> handler = (s, e) =>
                 {
                     if (e.IsChecked && _viewModel != null)
                     {
                         _viewModel.TransactionType = TransactionType.Income;
-                        // Desmarcar el otro
                         if (_expenseChip != null)
                             _expenseChip.Checked = false;
                     }
                 };
+
+                _incomeChip.CheckedChange += handler;
+                _uiEventSubscriptions.Add(new ActionDisposable(() => _incomeChip.CheckedChange -= handler));
             }
 
             if (_expenseChip != null)
             {
-                _expenseChip.CheckedChange += (s, e) =>
+                EventHandler<CompoundButton.CheckedChangeEventArgs> handler = (s, e) =>
                 {
                     if (e.IsChecked && _viewModel != null)
                     {
                         _viewModel.TransactionType = TransactionType.Expense;
-                        // Desmarcar el otro
                         if (_incomeChip != null)
                             _incomeChip.Checked = false;
                     }
                 };
+
+                _expenseChip.CheckedChange += handler;
+                _uiEventSubscriptions.Add(new ActionDisposable(() => _expenseChip.CheckedChange -= handler));
             }
 
-            // Date picker
             if (_dateEditText != null)
             {
-                _dateEditText.Click += ShowDatePicker;
-                _dateEditText.FocusChange += (s, e) =>
+                EventHandler handler = ShowDatePicker;
+                EventHandler<View.FocusChangeEventArgs> focusHandler = (s, e) =>
                 {
                     if (e.HasFocus) ShowDatePicker(s, EventArgs.Empty);
                 };
-            }
 
-            // Otros campos
-            if (_notesEditText != null)
-            {
-                _notesEditText.TextChanged += (s, e) =>
-                {
-                    if (_viewModel != null)
-                        _viewModel.Notes = e?.Text?.ToString() ?? string.Empty;
-                };
-            }
+                _dateEditText.Click += handler;
+                _dateEditText.FocusChange += focusHandler;
 
-            if (_locationEditText != null)
-            {
-                _locationEditText.TextChanged += (s, e) =>
+                _uiEventSubscriptions.Add(new ActionDisposable(() =>
                 {
-                    if (_viewModel != null)
-                        _viewModel.Location = e?.Text?.ToString() ?? string.Empty;
-                };
+                    _dateEditText.Click -= handler;
+                    _dateEditText.FocusChange -= focusHandler;
+                }));
             }
 
             if (_recurringCheckBox != null)
             {
-                _recurringCheckBox.CheckedChange += (s, e) =>
+                EventHandler<CompoundButton.CheckedChangeEventArgs> handler = (s, e) =>
                 {
                     if (_viewModel != null)
                         _viewModel.IsRecurring = e.IsChecked;
                 };
+
+                _recurringCheckBox.CheckedChange += handler;
+                _uiEventSubscriptions.Add(new ActionDisposable(() => _recurringCheckBox.CheckedChange -= handler));
+            }
+        }
+
+        private void SetupBindings()
+        {
+            if (_viewModel == null) return;
+
+            _bindings?.Dispose();
+            _bindings = new CompositeDisposable();
+
+            var culture = CultureInfo.CurrentCulture;
+
+            if (_descriptionEditText != null)
+            {
+                _bindings.Add(_viewModel.BindTwoWayThrottled(
+                    _descriptionEditText,
+                    vm => vm.Description,
+                    debounceMs: 150));
+            }
+
+            if (_amountEditText != null)
+            {
+                _bindings.Add(_viewModel.BindTwoWayThrottled(
+                    _amountEditText,
+                    vm => vm.Amount,
+                    debounceMs: 150,
+                    toStringConverter: value => value > 0 ? value.ToString("0.##", culture) : string.Empty,
+                    fromStringConverter: text =>
+                    {
+                        if (decimal.TryParse(text, NumberStyles.Number | NumberStyles.AllowCurrencySymbol, culture, out var amount))
+                        {
+                            return amount;
+                        }
+
+                        return _viewModel.Amount;
+                    }));
+            }
+
+            if (_notesEditText != null)
+            {
+                _bindings.Add(_viewModel.BindTwoWayThrottled(
+                    _notesEditText,
+                    vm => vm.Notes,
+                    debounceMs: 200));
+            }
+
+            if (_locationEditText != null)
+            {
+                _bindings.Add(_viewModel.BindTwoWayThrottled(
+                    _locationEditText,
+                    vm => vm.Location,
+                    debounceMs: 200));
             }
         }
 
@@ -227,18 +273,17 @@ namespace MoneyTracker.Presentation.Fragments
         {
             if (_viewModel == null) return;
 
-            // Observar cambios en propiedades
-            _viewModel.PropertyChanged += (s, e) =>
+            _viewModelSubscriptions?.Dispose();
+            _viewModelSubscriptions = new CompositeDisposable();
+
+            PropertyChangedEventHandler propertyChangedHandler = (s, e) =>
             {
                 Activity?.RunOnUiThread(() =>
                 {
                     switch (e.PropertyName)
                     {
                         case nameof(AddTransactionViewModel.Title):
-                            if (Activity is AppCompatActivity activity && activity.SupportActionBar != null)
-                            {
-                                activity.SupportActionBar.Title = _viewModel.Title;
-                            }
+                            UpdateTitle();
                             break;
                         case nameof(AddTransactionViewModel.CanSave):
                             if (_saveButton != null)
@@ -248,21 +293,56 @@ namespace MoneyTracker.Presentation.Fragments
                             UpdateBusyState();
                             break;
                         case nameof(AddTransactionViewModel.ValidationErrors):
+                        case nameof(AddTransactionViewModel.HasValidationErrors):
                             UpdateValidationErrors();
+                            break;
+                        case nameof(AddTransactionViewModel.TransactionType):
+                            UpdateTransactionTypeSelection();
+                            break;
+                        case nameof(AddTransactionViewModel.TransactionDate):
+                            if (_dateEditText != null)
+                                _dateEditText.Text = _viewModel.TransactionDate.ToString("dd/MM/yyyy");
+                            break;
+                        case nameof(AddTransactionViewModel.IsRecurring):
+                            if (_recurringCheckBox != null)
+                                _recurringCheckBox.Checked = _viewModel.IsRecurring;
+                            break;
+                        case nameof(AddTransactionViewModel.SelectedCategory):
+                            UpdateSelectedCategory();
                             break;
                     }
                 });
             };
 
-            // Observar cambios en categorías
-            _viewModel.Categories.CollectionChanged += (s, e) =>
+            _viewModel.PropertyChanged += propertyChangedHandler;
+            _viewModelSubscriptions.Add(new ActionDisposable(() => _viewModel.PropertyChanged -= propertyChangedHandler));
+
+            NotifyCollectionChangedEventHandler categoriesChangedHandler = (s, e) =>
             {
-                Activity?.RunOnUiThread(SetupCategorySpinner);
+                Activity?.RunOnUiThread(() =>
+                {
+                    SetupCategorySpinner();
+                    UpdateSelectedCategory();
+                });
             };
 
-            // Configuración inicial
+            _viewModel.Categories.CollectionChanged += categoriesChangedHandler;
+            _viewModelSubscriptions.Add(new ActionDisposable(() => _viewModel.Categories.CollectionChanged -= categoriesChangedHandler));
+
+            NotifyCollectionChangedEventHandler validationChangedHandler = (s, e) =>
+            {
+                Activity?.RunOnUiThread(UpdateValidationErrors);
+            };
+
+            _viewModel.ValidationErrors.CollectionChanged += validationChangedHandler;
+            _viewModelSubscriptions.Add(new ActionDisposable(() => _viewModel.ValidationErrors.CollectionChanged -= validationChangedHandler));
+
             LoadInitialValues();
             SetupCategorySpinner();
+            UpdateSelectedCategory();
+            SetupBindings();
+            UpdateBusyState();
+            UpdateValidationErrors();
         }
 
         /// <summary>
@@ -273,45 +353,17 @@ namespace MoneyTracker.Presentation.Fragments
             if (_viewModel == null) return;
 
             // Cargar valores del ViewModel
-            if (_descriptionEditText != null)
-                _descriptionEditText.Text = _viewModel.Description;
-
-            if (_amountEditText != null)
-                _amountEditText.Text = _viewModel.Amount > 0 ? _viewModel.Amount.ToString() : string.Empty;
-
             if (_dateEditText != null)
                 _dateEditText.Text = _viewModel.TransactionDate.ToString("dd/MM/yyyy");
-
-            if (_notesEditText != null)
-                _notesEditText.Text = _viewModel.Notes;
-
-            if (_locationEditText != null)
-                _locationEditText.Text = _viewModel.Location;
 
             if (_recurringCheckBox != null)
                 _recurringCheckBox.Checked = _viewModel.IsRecurring;
 
-            // Seleccionar chip de tipo
-            if (_viewModel.TransactionType == TransactionType.Income)
-            {
-                if (_incomeChip != null)
-                    _incomeChip.Checked = true;
-                if (_expenseChip != null)
-                    _expenseChip.Checked = false;
-            }
-            else
-            {
-                if (_expenseChip != null)
-                    _expenseChip.Checked = true;
-                if (_incomeChip != null)
-                    _incomeChip.Checked = false;
-            }
+            UpdateTransactionTypeSelection();
+            UpdateTitle();
 
-            // Título de la actividad
-            if (Activity is AppCompatActivity activity && activity.SupportActionBar != null)
-            {
-                activity.SupportActionBar.Title = _viewModel.Title;
-            }
+            if (_saveButton != null)
+                _saveButton.Enabled = _viewModel.CanSave;
         }
 
         /// <summary>
@@ -332,23 +384,68 @@ namespace MoneyTracker.Presentation.Fragments
             _categorySpinner.Adapter = adapter;
 
             // Seleccionar categoría actual
-            if (_viewModel.SelectedCategory != null)
+            UpdateSelectedCategory();
+
+            if (_categorySelectedHandler != null)
             {
-                var index = categories.FindIndex(c => c.Id == _viewModel.SelectedCategory.Id);
-                if (index >= 0)
-                {
-                    _categorySpinner.SetSelection(index);
-                }
+                _categorySpinner.ItemSelected -= _categorySelectedHandler;
             }
 
-            // Event handler para selección
-            _categorySpinner.ItemSelected += (s, e) =>
+            _categorySelectedHandler = (s, e) =>
             {
                 if (e.Position >= 0 && e.Position < categories.Count)
                 {
                     _viewModel.SelectedCategory = categories[e.Position];
                 }
             };
+
+            _categorySpinner.ItemSelected += _categorySelectedHandler;
+        }
+
+        private void UpdateTitle()
+        {
+            if (_viewModel == null) return;
+
+            if (Activity is AppCompatActivity activity && activity.SupportActionBar != null)
+            {
+                activity.SupportActionBar.Title = _viewModel.Title;
+            }
+        }
+
+        private void UpdateTransactionTypeSelection()
+        {
+            if (_viewModel == null) return;
+
+            var isIncome = _viewModel.TransactionType == TransactionType.Income;
+
+            if (_incomeChip != null && _incomeChip.Checked != isIncome)
+            {
+                _incomeChip.Checked = isIncome;
+            }
+
+            if (_expenseChip != null && _expenseChip.Checked == isIncome)
+            {
+                _expenseChip.Checked = !isIncome;
+            }
+        }
+
+        private void UpdateSelectedCategory()
+        {
+            if (_viewModel == null || _categorySpinner == null) return;
+
+            var categories = _viewModel.Categories.ToList();
+            if (categories.Count == 0)
+                return;
+
+            var selectedId = _viewModel.SelectedCategory?.Id;
+            if (selectedId == null)
+                return;
+
+            var index = categories.FindIndex(c => c.Id == selectedId);
+            if (index >= 0 && _categorySpinner.SelectedItemPosition != index)
+            {
+                _categorySpinner.SetSelection(index);
+            }
         }
 
         /// <summary>
@@ -422,6 +519,26 @@ namespace MoneyTracker.Presentation.Fragments
             );
 
             datePickerDialog.Show();
+        }
+
+        public override void OnDestroyView()
+        {
+            if (_categorySpinner != null && _categorySelectedHandler != null)
+            {
+                _categorySpinner.ItemSelected -= _categorySelectedHandler;
+                _categorySelectedHandler = null;
+            }
+
+            _bindings?.Dispose();
+            _bindings = null;
+
+            _viewModelSubscriptions?.Dispose();
+            _viewModelSubscriptions = null;
+
+            _uiEventSubscriptions?.Dispose();
+            _uiEventSubscriptions = null;
+
+            base.OnDestroyView();
         }
     }
 }


### PR DESCRIPTION
## Summary
- integrate the VirtualizedObservableCollection in the transaction list view model and expose pagination helpers
- update the transaction list fragment to consume the new collection, manage subscriptions safely, and support endless scrolling
- rework the add transaction fragment to use the thread-safe binding extensions and centralize UI event cleanup
- scope the AtomicReference utility and relax the adapter update signature for enumerable sources

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6079439f8832d83e16c6883f7163f