### PR TITLE
Add current activity provider for Android service registration

### DIFF
--- a/MoneyTrackerApplication.cs
+++ b/MoneyTrackerApplication.cs
@@ -1,3 +1,5 @@
+using Android.App;
+using Android.Content;
 using Android.Runtime;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -5,6 +7,8 @@ using Microsoft.Extensions.Logging;
 using MoneyTracker.Application.Services;
 using MoneyTracker.Infrastructure.Database;
 using MoneyTracker.Infrastructure.DependencyInjection;
+using MoneyTracker.Presentation.Services;
+using MoneyTracker.Presentation.Services.Interfaces;
 using System;
 using System.IO;
 
@@ -18,6 +22,7 @@ namespace MoneyTracker;
 public class MoneyTrackerApplication : Android.App.Application
 {
     public static IServiceProvider? ServiceProvider { get; private set; }
+    private CurrentActivityProvider? _currentActivityProvider;
 
     public MoneyTrackerApplication(IntPtr handle, JniHandleOwnership transer)
         : base(handle, transer)
@@ -30,6 +35,9 @@ public class MoneyTrackerApplication : Android.App.Application
 
         try
         {
+            _currentActivityProvider = new CurrentActivityProvider();
+            RegisterActivityLifecycleCallbacks(_currentActivityProvider);
+
             // Configurar inyección de dependencias
             ConfigureServices();
 
@@ -65,7 +73,21 @@ public class MoneyTrackerApplication : Android.App.Application
         // Configurar ruta de base de datos
         var dbPath = GetDatabasePath();
         var connectionString = $"Data Source={dbPath}";
+        if (_currentActivityProvider == null)
+        {
+            throw new InvalidOperationException("El proveedor de actividad actual no ha sido inicializado.");
+        }
+
+        Func<Activity> activityProviderFunc = () => _currentActivityProvider.GetCurrentActivity();
+        Func<Context> contextProviderFunc = () => activityProviderFunc();
+
         // Servicios
+        services.AddSingleton<Func<Activity>>(activityProviderFunc);
+        services.AddSingleton<Func<Context>>(contextProviderFunc);
+        services.AddSingleton<IDialogService>(sp => new AndroidDialogService(sp.GetRequiredService<Func<Context>>()));
+        services.AddSingleton<INavigationService>(sp => new AndroidNavigationService(sp.GetRequiredService<Func<Activity>>(), sp));
+        services.AddSingleton<ICacheService>(_ => new AndroidCacheService(ApplicationContext));
+        services.AddSingleton<IMediaPickerService>(sp => new AndroidMediaPickerService(sp.GetRequiredService<Func<Activity>>()));
         services.AddSingleton<MoneyTracker.Presentation.Navigation.INavigator, MoneyTracker.Presentation.Navigation.Navigator>();
 
         // ViewModels
@@ -118,6 +140,10 @@ public class MoneyTrackerApplication : Android.App.Application
             _ = ServiceProvider!.GetRequiredService<MoneyTrackerContext>();
             _ = ServiceProvider.GetRequiredService<TransactionAppService>();
             _ = ServiceProvider.GetRequiredService<CategoryAppService>();
+            _ = ServiceProvider.GetRequiredService<IDialogService>();
+            _ = ServiceProvider.GetRequiredService<INavigationService>();
+            _ = ServiceProvider.GetRequiredService<ICacheService>();
+            _ = ServiceProvider.GetRequiredService<IMediaPickerService>();
 
             System.Diagnostics.Debug.WriteLine("✅ Service configuration validated successfully");
         }
@@ -180,6 +206,11 @@ public class MoneyTrackerApplication : Android.App.Application
             using var scope = ServiceProvider?.CreateScope();
             var context = scope?.ServiceProvider.GetService<MoneyTrackerContext>();
             context?.Dispose();
+
+            if (_currentActivityProvider != null)
+            {
+                UnregisterActivityLifecycleCallbacks(_currentActivityProvider);
+            }
 
             // Dispose del ServiceProvider
             if (ServiceProvider is IDisposable disposable)

--- a/Presentation/Services/CurrentActivityProvider.cs
+++ b/Presentation/Services/CurrentActivityProvider.cs
@@ -1,0 +1,85 @@
+using Android.App;
+using Android.OS;
+using System;
+
+namespace MoneyTracker.Presentation.Services;
+
+public class CurrentActivityProvider : Java.Lang.Object, Application.IActivityLifecycleCallbacks
+{
+    private readonly object _syncRoot = new();
+    private Activity? _currentActivity;
+
+    public Activity GetCurrentActivity()
+    {
+        var activity = CurrentActivity;
+        if (activity == null)
+        {
+            throw new InvalidOperationException("No hay una actividad actual disponible.");
+        }
+
+        return activity;
+    }
+
+    public Activity? CurrentActivity
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _currentActivity;
+            }
+        }
+    }
+
+    public void OnActivityCreated(Activity activity, Bundle? savedInstanceState)
+    {
+        SetCurrentActivity(activity);
+    }
+
+    public void OnActivityDestroyed(Activity activity)
+    {
+        ClearActivity(activity);
+    }
+
+    public void OnActivityPaused(Activity activity)
+    {
+    }
+
+    public void OnActivityResumed(Activity activity)
+    {
+        SetCurrentActivity(activity);
+    }
+
+    public void OnActivitySaveInstanceState(Activity activity, Bundle? outState)
+    {
+    }
+
+    public void OnActivityStarted(Activity activity)
+    {
+        SetCurrentActivity(activity);
+    }
+
+    public void OnActivityStopped(Activity activity)
+    {
+        ClearActivity(activity, onlyIfSame: true);
+    }
+
+    private void SetCurrentActivity(Activity activity)
+    {
+        lock (_syncRoot)
+        {
+            _currentActivity = activity;
+        }
+    }
+
+    private void ClearActivity(Activity activity, bool onlyIfSame = false)
+    {
+        lock (_syncRoot)
+        {
+            if (!onlyIfSame || ReferenceEquals(_currentActivity, activity))
+            {
+                _currentActivity = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- register Android dialog, navigation, cache, and media picker services with DI using activity/context providers
- add a lifecycle-based current activity provider and wire it into application startup and shutdown
- validate that the new critical services resolve correctly during service configuration

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d612bbdb48832da88e83fbdddbee32