### PR TITLE
Refactor viewmodels to use navigation and dialog services

### DIFF
--- a/Presentation/Activities/MainActivity.cs
+++ b/Presentation/Activities/MainActivity.cs
@@ -1,15 +1,10 @@
 ﻿using Android;
 using Android.Views;
-using Android.Widget;
 using AndroidX.AppCompat.App;
 using Microsoft.Extensions.DependencyInjection;
 using Java.Lang;
 
-using CommunityToolkit.Mvvm.Messaging;
-using MoneyTracker.Application.DTOs;
 using MoneyTracker.Presentation.Fragments;
-using MoneyTracker.Presentation.Messages;   
-using MoneyTracker.Presentation.ViewModels;
 
 namespace MoneyTracker.Presentation.Activities
 {
@@ -25,15 +20,6 @@ namespace MoneyTracker.Presentation.Activities
             {
                 LoadInitialFragment();
             }
-
-            SubscribeToNavigationEvents();
-        }
-
-        protected override void OnDestroy()
-        {
-            // ✅ Con WeakReferenceMessenger: limpiar todas las suscripciones de este recipient
-            WeakReferenceMessenger.Default.UnregisterAll(this);
-            base.OnDestroy();
         }
 
         private void LoadInitialFragment()
@@ -48,124 +34,9 @@ namespace MoneyTracker.Presentation.Activities
             }
         }
 
-        private void SubscribeToNavigationEvents()
-        {
-            // NavigateToAddTransaction
-            WeakReferenceMessenger.Default.Register<NavigateToAddTransactionMessage>(this, (recipient, msg) =>
-            {
-                if (IsActivityValid())
-                {
-                    var fragment = new AddTransactionFragment();
-                    NavigateToFragment(fragment, "AddTransaction");
-                }
-            });
-
-            // NavigateToEditTransaction (lleva TransactionDto en msg.Value)
-            WeakReferenceMessenger.Default.Register<NavigateToEditTransactionMessage>(this, (recipient, msg) =>
-            {
-                if (IsActivityValid())
-                {
-                    var fragment = AddTransactionFragment.NewInstanceForEdit(msg.Value);
-                    NavigateToFragment(fragment, "EditTransaction");
-                }
-            });
-
-            // NavigateBack
-            WeakReferenceMessenger.Default.Register<NavigateBackMessage>(this, (recipient, msg) =>
-            {
-                if (IsActivityValid())
-                {
-                    if (SupportFragmentManager.BackStackEntryCount > 0)
-                    {
-                        SupportFragmentManager.PopBackStack();
-                    }
-                    else
-                    {
-                        Finish();
-                    }
-                }
-            });
-
-            // ShowMessage (Toast/Snackbar)
-            WeakReferenceMessenger.Default.Register<ShowMessageMessage>(this, (recipient, msg) =>
-            {
-                if (IsActivityValid())
-                {
-                    ShowToast(msg.Value);
-                }
-            });
-
-            // ShowError (Dialog)
-            WeakReferenceMessenger.Default.Register<ShowErrorMessage>(this, (recipient, msg) =>
-            {
-                if (IsActivityValid())
-                {
-                    ShowErrorDialog(msg.Value);
-                }
-            });
-        }
-
         private bool IsActivityValid()
         {
             return !IsFinishing && !IsDestroyed && SupportFragmentManager != null && !SupportFragmentManager.IsDestroyed;
-        }
-
-        private void NavigateToFragment(AndroidX.Fragment.App.Fragment fragment, string tag)
-        {
-            try
-            {
-                if (IsActivityValid())
-                {
-                    var transaction = SupportFragmentManager.BeginTransaction();
-                    transaction.Replace(Resource.Id.fragment_container, fragment);
-                    transaction.AddToBackStack(tag);
-                    transaction.CommitAllowingStateLoss(); // más seguro si el estado ya se guardó
-                }
-            }
-            catch (Java.Lang.IllegalStateException ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"NavigateToFragment error: {ex.Message}");
-            }
-        }
-
-        private void ShowToast(string message)
-        {
-            try
-            {
-                RunOnUiThread(() =>
-                {
-                    if (IsActivityValid())
-                    {
-                        Toast.MakeText(this, message, ToastLength.Short)?.Show();
-                    }
-                });
-            }
-            catch (System.Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"ShowToast error: {ex.Message}");
-            }
-        }
-
-        private void ShowErrorDialog(string error)
-        {
-            try
-            {
-                RunOnUiThread(() =>
-                {
-                    if (IsActivityValid())
-                    {
-                        new AndroidX.AppCompat.App.AlertDialog.Builder(this)
-                            .SetTitle("Error")
-                            .SetMessage(error)
-                            .SetPositiveButton("OK", (sender, e) => { })
-                            .Show();
-                    }
-                });
-            }
-            catch (System.Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"ShowErrorDialog error: {ex.Message}");
-            }
         }
 
         public override bool OnCreateOptionsMenu(IMenu? menu)

--- a/Presentation/Messages/NavigateBackMessage.cs
+++ b/Presentation/Messages/NavigateBackMessage.cs
@@ -1,8 +1,0 @@
-﻿using CommunityToolkit.Mvvm.Messaging.Messages;
-
-namespace MoneyTracker.Presentation.Messages;
-
-public sealed class NavigateBackMessage : ValueChangedMessage<bool>
-{
-    public NavigateBackMessage() : base(true) { }
-}

--- a/Presentation/Messages/NavigateToAddTransactionMessage.cs
+++ b/Presentation/Messages/NavigateToAddTransactionMessage.cs
@@ -1,8 +1,0 @@
-﻿using CommunityToolkit.Mvvm.Messaging.Messages;
-
-namespace MoneyTracker.Presentation.Messages;
-
-public sealed class NavigateToAddTransactionMessage : ValueChangedMessage<bool>
-{
-    public NavigateToAddTransactionMessage() : base(true) { }
-}

--- a/Presentation/Messages/NavigateToEditTransactionMessage.cs
+++ b/Presentation/Messages/NavigateToEditTransactionMessage.cs
@@ -1,9 +1,0 @@
-﻿using CommunityToolkit.Mvvm.Messaging.Messages;
-using MoneyTracker.Application.DTOs;
-
-namespace MoneyTracker.Presentation.Messages;
-
-public sealed class NavigateToEditTransactionMessage : ValueChangedMessage<TransactionDto>
-{
-    public NavigateToEditTransactionMessage(TransactionDto value) : base(value) { }
-}

--- a/Presentation/Messages/ShowErrorMessage.cs
+++ b/Presentation/Messages/ShowErrorMessage.cs
@@ -1,8 +1,0 @@
-﻿using CommunityToolkit.Mvvm.Messaging.Messages;
-
-namespace MoneyTracker.Presentation.Messages;
-
-public sealed class ShowErrorMessage : ValueChangedMessage<string>
-{
-    public ShowErrorMessage(string error) : base(error) { }
-}

--- a/Presentation/Messages/ShowMessageMessage.cs
+++ b/Presentation/Messages/ShowMessageMessage.cs
@@ -1,8 +1,0 @@
-﻿using CommunityToolkit.Mvvm.Messaging.Messages;
-
-namespace MoneyTracker.Presentation.Messages;
-
-public sealed class ShowMessageMessage : ValueChangedMessage<string>
-{
-    public ShowMessageMessage(string text) : base(text) { }
-}

--- a/Presentation/Messages/TransactionSavedMessage.cs
+++ b/Presentation/Messages/TransactionSavedMessage.cs
@@ -1,9 +1,0 @@
-﻿using CommunityToolkit.Mvvm.Messaging.Messages;
-using MoneyTracker.Application.DTOs;
-
-namespace MoneyTracker.Presentation.Messages;
-
-public sealed class TransactionSavedMessage : ValueChangedMessage<TransactionDto>
-{
-    public TransactionSavedMessage(TransactionDto value) : base(value) { }
-}

--- a/Presentation/Messages/TransactionUpdatedMessage.cs
+++ b/Presentation/Messages/TransactionUpdatedMessage.cs
@@ -1,9 +1,0 @@
-﻿using CommunityToolkit.Mvvm.Messaging.Messages;
-using MoneyTracker.Application.DTOs;
-
-namespace MoneyTracker.Presentation.Messages;
-
-public sealed class TransactionUpdatedMessage : ValueChangedMessage<TransactionDto>
-{
-    public TransactionUpdatedMessage(TransactionDto value) : base(value) { }
-}

--- a/Presentation/Services/AndroidNavigationService.cs
+++ b/Presentation/Services/AndroidNavigationService.cs
@@ -1,4 +1,5 @@
 ﻿using Android.Content;
+using MoneyTracker.Application.DTOs;
 using MoneyTracker.Presentation.Activities;
 using MoneyTracker.Presentation.Fragments;
 using MoneyTracker.Presentation.Services.Interfaces;
@@ -139,7 +140,16 @@ public class AndroidNavigationService : INavigationService
     {
         var bundle = new Bundle();
         var json = Newtonsoft.Json.JsonConvert.SerializeObject(parameters);
-        bundle.PutString("parameters", json);
+
+        if (parameters is TransactionDto)
+        {
+            bundle.PutString("transaction_json", json);
+        }
+        else
+        {
+            bundle.PutString("parameters", json);
+        }
+
         return bundle;
     }
 }


### PR DESCRIPTION
## Summary
- inject navigation and dialog services into the transaction list, add transaction, and settings view models to replace messenger-based navigation and notifications
- update the Android navigation service to pass transaction payloads to the edit screen and simplify MainActivity now that messenger hooks are gone
- remove the obsolete messenger message types

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d611e99c80832db049bd83af11905f