### PR TITLE
Refine fragment parameter key for transaction editing

### DIFF
--- a/Presentation/Fragments/AddTransactionFragment.cs
+++ b/Presentation/Fragments/AddTransactionFragment.cs
@@ -5,6 +5,7 @@ using AndroidX.Fragment.App;
 using MoneyTracker.Application.DTOs;
 using MoneyTracker.Core.Enums;
 using MoneyTracker.Presentation.Extensions;
+using MoneyTracker.Presentation.Navigation;
 using MoneyTracker.Presentation.ViewModels;
 using Google.Android.Material.TextField;
 using System;
@@ -54,7 +55,7 @@ namespace MoneyTracker.Presentation.Fragments
         {
             var fragment = new AddTransactionFragment();
             var args = new Bundle();
-            args.PutString("transaction_json", Newtonsoft.Json.JsonConvert.SerializeObject(transaction));
+            args.PutString(NavigationParameterKeys.FragmentParameters, Newtonsoft.Json.JsonConvert.SerializeObject(transaction));
             fragment.Arguments = args;
             return fragment;
         }
@@ -249,7 +250,7 @@ namespace MoneyTracker.Presentation.Fragments
         /// </summary>
         private void CheckEditMode()
         {
-            if (Arguments?.GetString("transaction_json") is string json && !string.IsNullOrEmpty(json))
+            if (Arguments?.GetString(NavigationParameterKeys.FragmentParameters) is string json && !string.IsNullOrEmpty(json))
             {
                 try
                 {

--- a/Presentation/Navigation/NavigationParameterKeys.cs
+++ b/Presentation/Navigation/NavigationParameterKeys.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Presentation.Navigation;
+
+public static class NavigationParameterKeys
+{
+    public const string FragmentParameters = "navigation_fragment_parameters";
+}

--- a/Presentation/Services/AndroidNavigationService.cs
+++ b/Presentation/Services/AndroidNavigationService.cs
@@ -1,6 +1,7 @@
 ﻿using Android.Content;
 using MoneyTracker.Presentation.Activities;
 using MoneyTracker.Presentation.Fragments;
+using MoneyTracker.Presentation.Navigation;
 using MoneyTracker.Presentation.Services.Interfaces;
 using MoneyTracker.Presentation.ViewModels;
 
@@ -139,7 +140,7 @@ public class AndroidNavigationService : INavigationService
     {
         var bundle = new Bundle();
         var json = Newtonsoft.Json.JsonConvert.SerializeObject(parameters);
-        bundle.PutString("parameters", json);
+        bundle.PutString(NavigationParameterKeys.FragmentParameters, json);
         return bundle;
     }
 }


### PR DESCRIPTION
## Summary
- add a shared navigation parameter key constant for fragment arguments
- use the common key when serializing and deserializing transaction data for the edit transaction flow

## Testing
- Not run (dotnet not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d612be46b0832d9467244b34a6601f