### PR TITLE
Fix dependency injection configuration for Android services

### DIFF
--- a/MoneyTrackerApplication.cs
+++ b/MoneyTrackerApplication.cs
@@ -79,32 +79,11 @@ public class MoneyTrackerApplication : Android.App.Application
             throw new InvalidOperationException("El proveedor de actividad actual no ha sido inicializado.");
         }
 
-        Func<Activity> activityProviderFunc = () => _currentActivityProvider.GetCurrentActivity();
-        Func<Context> contextProviderFunc = () => activityProviderFunc();
-
-
-        services.AddSingleton<Func<Activity>>(_ => () =>
-        {
-            var activity = CurrentActivityHolder.Current;
-            return activity ?? throw new InvalidOperationException("No hay una actividad actual registrada para navegación.");
-        });
-
-        services.AddSingleton<Func<Context>>(_ => () =>
-        {
-            return CurrentActivityHolder.Current ?? ApplicationContext!;
-        });
-
-        services.AddSingleton<IDialogService, AndroidDialogService>();
-        services.AddSingleton<INavigationService, AndroidNavigationService>();
-        services.AddSingleton<ICacheService>(_ => new AndroidCacheService(ApplicationContext!));
-             
-
-        // Servicios
-        services.AddSingleton<Func<Activity>>(activityProviderFunc);
-        services.AddSingleton<Func<Context>>(contextProviderFunc);
+        services.AddSingleton<Func<Activity>>(_ => () => _currentActivityProvider.GetCurrentActivity());
+        services.AddSingleton<Func<Context>>(sp => () => sp.GetRequiredService<Func<Activity>>()());
         services.AddSingleton<IDialogService>(sp => new AndroidDialogService(sp.GetRequiredService<Func<Context>>()));
-        services.AddSingleton<INavigationService>(sp => new AndroidNavigationService(sp.GetRequiredService<Func<Activity>>(), sp));
-        services.AddSingleton<ICacheService>(_ => new AndroidCacheService(ApplicationContext));
+        services.AddSingleton<INavigationService>(sp => new AndroidNavigationService(sp.GetRequiredService<Func<Activity>>()));
+        services.AddSingleton<ICacheService>(_ => new AndroidCacheService(ApplicationContext ?? throw new InvalidOperationException("ApplicationContext no disponible")));
         services.AddSingleton<IMediaPickerService>(sp => new AndroidMediaPickerService(sp.GetRequiredService<Func<Activity>>()));
         services.AddSingleton<MoneyTracker.Presentation.Navigation.INavigator, MoneyTracker.Presentation.Navigation.Navigator>();
 


### PR DESCRIPTION
## Summary
- streamline Android service registrations to rely on the initialized `CurrentActivityProvider`
- remove duplicate dependency injection registrations that conflicted with constructor requirements
- guard cache service creation with an explicit `ApplicationContext` null check to avoid runtime failures

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6c3ea4f1c832d9103eb5bc6384bde