### PR TITLE
Fix RecyclerView fixed size call

### DIFF
--- a/Presentation/Fragments/TransactionListFragment.cs
+++ b/Presentation/Fragments/TransactionListFragment.cs
@@ -112,7 +112,7 @@ namespace MoneyTracker.Presentation.Fragments
             {
                 _layoutManager = new LinearLayoutManager(Context);
                 _recyclerView.SetLayoutManager(_layoutManager);
-                _recyclerView.SetHasFixedSize(true);
+                _recyclerView.HasFixedSize = true;
 
                 _adapter = new TransactionAdapter();
                 _recyclerView.SetAdapter(_adapter);


### PR DESCRIPTION
## Summary
- replace the deprecated SetHasFixedSize call with the HasFixedSize property when configuring the transaction list RecyclerView

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d72f836250832d80d3e263fa6df27d