### PR TITLE
Prevent activity trimming from removing MainActivity

### DIFF
--- a/MoneyTracker.csproj
+++ b/MoneyTracker.csproj
@@ -8,7 +8,11 @@
 		<ApplicationId>com.companyname.MoneyTracker</ApplicationId>
 		<ApplicationVersion>1</ApplicationVersion>
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-		<TrimMode>full</TrimMode>
+                <!-- Using full trimming on Android removes the generated Java wrapper
+                     for our activities, which prevents the runtime from locating
+                     MainActivity.  Revert to the safer partial trimming mode so
+                     the managed types that need Java bindings stay intact. -->
+                <TrimMode>partial</TrimMode>
 
              <!-- ✅ CRITICAL: Disable warnings as errors -->
 		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>


### PR DESCRIPTION
## Summary
- switch the Android project back to partial trimming so the Java wrappers for activities are preserved
- document why the safer trimming mode is necessary to avoid the MainActivity class not found crash

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7173ab9d4832db91ea1d4e068555f