### PR TITLE
Add extended settings layout with warehouse spinners

### DIFF
--- a/Resources/layout/activity_settings_extended.xml
+++ b/Resources/layout/activity_settings_extended.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:background="@color/background_light">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/txtSettingsTitle"
+            style="@style/SettingsHeader"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_title" />
+
+        <LinearLayout
+            android:id="@+id/layoutInventorySettings"
+            style="@style/SettingsSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/txtInventoryHeader"
+                style="@style/SettingsSectionTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_section_inventory" />
+
+            <TextView
+                android:id="@+id/lblWarehouse"
+                style="@style/SettingsLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_warehouse_label" />
+
+            <Spinner
+                android:id="@+id/spinnerWarehouse"
+                style="@style/SettingsSpinner" />
+
+            <TextView
+                android:id="@+id/lblReceivingBin"
+                style="@style/SettingsLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_receiving_bin_label" />
+
+            <Spinner
+                android:id="@+id/spinnerReceivingBin"
+                style="@style/SettingsSpinner" />
+
+            <TextView
+                android:id="@+id/lblZone"
+                style="@style/SettingsLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_zone_label" />
+
+            <Spinner
+                android:id="@+id/spinnerZone"
+                style="@style/SettingsSpinner" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/layoutFulfillmentSettings"
+            style="@style/SettingsSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/txtFulfillmentHeader"
+                style="@style/SettingsSectionTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_section_fulfillment" />
+
+            <TextView
+                android:id="@+id/lblShippingBin"
+                style="@style/SettingsLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_shipping_bin_label" />
+
+            <Spinner
+                android:id="@+id/spinnerShippingBin"
+                style="@style/SettingsSpinner" />
+
+            <TextView
+                android:id="@+id/lblPrinter"
+                style="@style/SettingsLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_printer_label" />
+
+            <Spinner
+                android:id="@+id/spinnerPrinter"
+                style="@style/SettingsSpinner" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/btnSaveSettings"
+            style="@style/PrimaryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/button_save" />
+    </LinearLayout>
+</ScrollView>

--- a/Resources/values/strings.xml
+++ b/Resources/values/strings.xml
@@ -39,4 +39,14 @@
         <string name="error_required_field">This field is required</string>
         <string name="error_invalid_amount">Invalid amount</string>
         <string name="error_connection">Connection error</string>
+
+        <!-- Settings -->
+        <string name="settings_title">Warehouse configuration</string>
+        <string name="settings_section_inventory">Inventory settings</string>
+        <string name="settings_section_fulfillment">Fulfillment settings</string>
+        <string name="settings_warehouse_label">Warehouse</string>
+        <string name="settings_receiving_bin_label">Receiving bin</string>
+        <string name="settings_shipping_bin_label">Shipping bin</string>
+        <string name="settings_zone_label">Zone</string>
+        <string name="settings_printer_label">Printer</string>
 </resources>

--- a/Resources/values/styles.xml
+++ b/Resources/values/styles.xml
@@ -1,35 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
         <!-- Primary theme -->
-	<style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
-		<item name="colorPrimary">@color/colorPrimary</item>
-		<item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-		<item name="colorAccent">@color/colorAccent</item>
-		<item name="android:windowBackground">@color/background_light</item>
-	</style>
-	<style name="MainTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-		<item name="colorPrimary">#2196F3</item>
-		<item name="colorPrimaryDark">#1976D2</item>
-		<item name="colorAccent">#FF4081</item>
-	</style>
+        <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
+                <item name="colorPrimary">@color/colorPrimary</item>
+                <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+                <item name="colorAccent">@color/colorAccent</item>
+                <item name="android:windowBackground">@color/background_light</item>
+        </style>
+        <style name="MainTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+                <item name="colorPrimary">#2196F3</item>
+                <item name="colorPrimaryDark">#1976D2</item>
+                <item name="colorAccent">#FF4081</item>
+        </style>
         <!-- Styles for forms -->
-	<style name="FormTextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-		<item name="boxStrokeColor">@color/colorPrimary</item>
-		<item name="hintTextColor">@color/colorPrimary</item>
-	</style>
+        <style name="FormTextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+                <item name="boxStrokeColor">@color/colorPrimary</item>
+                <item name="hintTextColor">@color/colorPrimary</item>
+        </style>
 
         <!-- Styles for buttons -->
-	<style name="PrimaryButton" parent="Widget.MaterialComponents.Button">
-		<item name="backgroundTint">@color/colorPrimary</item>
-		<item name="android:textColor">@android:color/white</item>
-		<item name="cornerRadius">8dp</item>
-	</style>
+        <style name="PrimaryButton" parent="Widget.MaterialComponents.Button">
+                <item name="backgroundTint">@color/colorPrimary</item>
+                <item name="android:textColor">@android:color/white</item>
+                <item name="cornerRadius">8dp</item>
+        </style>
 
         <!-- Styles for cards -->
-	<style name="TransactionCard" parent="Widget.MaterialComponents.CardView">
-		<item name="cardCornerRadius">8dp</item>
-		<item name="cardElevation">2dp</item>
-		<item name="cardUseCompatPadding">true</item>
-	</style>
+        <style name="TransactionCard" parent="Widget.MaterialComponents.CardView">
+                <item name="cardCornerRadius">8dp</item>
+                <item name="cardElevation">2dp</item>
+                <item name="cardUseCompatPadding">true</item>
+        </style>
+
+        <!-- Settings specific styles -->
+        <style name="SettingsHeader" parent="TextAppearance.MaterialComponents.Headline6">
+                <item name="android:textColor">@color/on_surface</item>
+                <item name="android:textStyle">bold</item>
+                <item name="android:layout_marginBottom">16dp</item>
+        </style>
+
+        <style name="SettingsSection">
+                <item name="android:background">@color/surface</item>
+                <item name="android:padding">16dp</item>
+                <item name="android:layout_marginBottom">16dp</item>
+                <item name="android:elevation">2dp</item>
+        </style>
+
+        <style name="SettingsSectionTitle" parent="TextAppearance.MaterialComponents.Subtitle1">
+                <item name="android:textColor">@color/on_surface</item>
+                <item name="android:textStyle">bold</item>
+                <item name="android:layout_marginBottom">12dp</item>
+        </style>
+
+        <style name="SettingsLabel" parent="TextAppearance.MaterialComponents.Body2">
+                <item name="android:textColor">@color/on_surface</item>
+                <item name="android:layout_marginBottom">8dp</item>
+        </style>
+
+        <style name="SettingsSpinner">
+                <item name="android:layout_width">match_parent</item>
+                <item name="android:layout_height">wrap_content</item>
+                <item name="android:layout_marginBottom">16dp</item>
+        </style>
 
 </resources>


### PR DESCRIPTION
## Summary
- add an extended settings layout with structured sections for warehouse and fulfillment spinners
- introduce dedicated styles to keep the new settings screen visually consistent
- provide string resources for the new labels and section headers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc6a2df164832da4eb5fe0c2ef42c2