### PR TITLE
Implement warehouse configuration settings view model

### DIFF
--- a/Application/DTOs/WarehouseSettingsDto.cs
+++ b/Application/DTOs/WarehouseSettingsDto.cs
@@ -1,0 +1,20 @@
+namespace MoneyTracker.Application.DTOs;
+
+public sealed class WarehouseSettingsDto
+{
+    public string? WarehouseId { get; set; }
+
+    public string? Zone { get; set; }
+
+    public string? ReceivingBin { get; set; }
+
+    public string? ShippingBin { get; set; }
+
+    public string? PrinterName { get; set; }
+
+    public string? QuickCountType { get; set; }
+
+    public bool ShowZones { get; set; }
+
+    public bool ShowPrinters { get; set; }
+}

--- a/Application/Services/Interfaces/IAcumaticaOptionsProvider.cs
+++ b/Application/Services/Interfaces/IAcumaticaOptionsProvider.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace MoneyTracker.Application.Services.Interfaces;
+
+public interface IAcumaticaOptionsProvider
+{
+    IReadOnlyList<string> GetQuickCountTypes();
+
+    bool ShouldShowZones(string warehouseId);
+
+    bool ShouldShowPrinters();
+}

--- a/Application/Services/Interfaces/ICommonQueryService.cs
+++ b/Application/Services/Interfaces/ICommonQueryService.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MoneyTracker.Application.Services.Interfaces;
+
+public interface ICommonQueryService
+{
+    Task<IReadOnlyList<string>> GetWarehouseIdsAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<string>> GetZonesAsync(string warehouseId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<string>> GetReceivingBinsAsync(string warehouseId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<string>> GetShippingBinsAsync(string warehouseId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<string>> GetPrintersAsync(CancellationToken cancellationToken = default);
+}

--- a/Application/Services/Interfaces/ISettingsService.cs
+++ b/Application/Services/Interfaces/ISettingsService.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MoneyTracker.Application.DTOs;
+
+namespace MoneyTracker.Application.Services.Interfaces;
+
+public interface ISettingsService
+{
+    Task<WarehouseSettingsDto?> GetWarehouseSettingsAsync(CancellationToken cancellationToken = default);
+
+    Task SaveWarehouseSettingsAsync(WarehouseSettingsDto settings, CancellationToken cancellationToken = default);
+}

--- a/Infrastructure/Services/AcumaticaOptionsProvider.cs
+++ b/Infrastructure/Services/AcumaticaOptionsProvider.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using MoneyTracker.Application.Services.Interfaces;
+
+namespace MoneyTracker.Infrastructure.Services;
+
+public sealed class AcumaticaOptionsProvider : IAcumaticaOptionsProvider
+{
+    private static readonly IReadOnlyList<string> _quickCountTypes = new List<string>
+    {
+        "Cycle Count",
+        "Full Count",
+        "Spot Check"
+    };
+
+    public IReadOnlyList<string> GetQuickCountTypes() => _quickCountTypes;
+
+    public bool ShouldShowZones(string warehouseId)
+    {
+        return !string.IsNullOrWhiteSpace(warehouseId);
+    }
+
+    public bool ShouldShowPrinters() => true;
+}

--- a/Infrastructure/Services/CommonQueryService.cs
+++ b/Infrastructure/Services/CommonQueryService.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MoneyTracker.Application.Services.Interfaces;
+
+namespace MoneyTracker.Infrastructure.Services;
+
+public sealed class CommonQueryService : ICommonQueryService
+{
+    private readonly IReadOnlyDictionary<string, WarehouseMetadata> _warehouses;
+    private readonly IReadOnlyList<string> _printers;
+
+    public CommonQueryService()
+    {
+        _warehouses = new Dictionary<string, WarehouseMetadata>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["MAIN"] = new WarehouseMetadata(
+                new List<string> { "A", "B" },
+                new List<string> { "R1", "R2", "R3" },
+                new List<string> { "S1", "S2" }),
+            ["SECONDARY"] = new WarehouseMetadata(
+                new List<string> { "NORTH", "SOUTH" },
+                new List<string> { "RN1" },
+                new List<string> { "SN1", "SN2", "SN3" }),
+            ["OUTLET"] = new WarehouseMetadata(
+                new List<string>(),
+                new List<string> { "OR1" },
+                new List<string> { "OS1" })
+        };
+
+        _printers = new List<string> { "PRT-01", "PRT-02", "PRT-03" };
+    }
+
+    public Task<IReadOnlyList<string>> GetWarehouseIdsAsync(CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<string> result = _warehouses.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase).ToList();
+        return Task.FromResult(result);
+    }
+
+    public Task<IReadOnlyList<string>> GetZonesAsync(string warehouseId, CancellationToken cancellationToken = default)
+    {
+        var zones = ResolveWarehouse(warehouseId).Zones;
+        return Task.FromResult<IReadOnlyList<string>>(zones);
+    }
+
+    public Task<IReadOnlyList<string>> GetReceivingBinsAsync(string warehouseId, CancellationToken cancellationToken = default)
+    {
+        var bins = ResolveWarehouse(warehouseId).ReceivingBins;
+        return Task.FromResult<IReadOnlyList<string>>(bins);
+    }
+
+    public Task<IReadOnlyList<string>> GetShippingBinsAsync(string warehouseId, CancellationToken cancellationToken = default)
+    {
+        var bins = ResolveWarehouse(warehouseId).ShippingBins;
+        return Task.FromResult<IReadOnlyList<string>>(bins);
+    }
+
+    public Task<IReadOnlyList<string>> GetPrintersAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(_printers);
+
+    private WarehouseMetadata ResolveWarehouse(string warehouseId)
+    {
+        if (string.IsNullOrWhiteSpace(warehouseId))
+        {
+            return WarehouseMetadata.Empty;
+        }
+
+        return _warehouses.TryGetValue(warehouseId, out var metadata)
+            ? metadata
+            : WarehouseMetadata.Empty;
+    }
+
+    private sealed class WarehouseMetadata
+    {
+        public WarehouseMetadata(IReadOnlyList<string> zones, IReadOnlyList<string> receivingBins, IReadOnlyList<string> shippingBins)
+        {
+            Zones = zones ?? Array.Empty<string>();
+            ReceivingBins = receivingBins ?? Array.Empty<string>();
+            ShippingBins = shippingBins ?? Array.Empty<string>();
+        }
+
+        public static WarehouseMetadata Empty { get; } = new(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+
+        public IReadOnlyList<string> Zones { get; }
+
+        public IReadOnlyList<string> ReceivingBins { get; }
+
+        public IReadOnlyList<string> ShippingBins { get; }
+    }
+}

--- a/Infrastructure/Services/InMemorySettingsService.cs
+++ b/Infrastructure/Services/InMemorySettingsService.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MoneyTracker.Application.DTOs;
+using MoneyTracker.Application.Services.Interfaces;
+
+namespace MoneyTracker.Infrastructure.Services;
+
+public sealed class InMemorySettingsService : ISettingsService
+{
+    private readonly SemaphoreSlim _sync = new(1, 1);
+    private WarehouseSettingsDto? _settings;
+
+    public async Task<WarehouseSettingsDto?> GetWarehouseSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        await _sync.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return _settings == null ? null : Clone(_settings);
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    public async Task SaveWarehouseSettingsAsync(WarehouseSettingsDto settings, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        await _sync.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _settings = Clone(settings);
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    private static WarehouseSettingsDto Clone(WarehouseSettingsDto source)
+        => new()
+        {
+            WarehouseId = source.WarehouseId,
+            Zone = source.Zone,
+            ReceivingBin = source.ReceivingBin,
+            ShippingBin = source.ShippingBin,
+            PrinterName = source.PrinterName,
+            QuickCountType = source.QuickCountType,
+            ShowZones = source.ShowZones,
+            ShowPrinters = source.ShowPrinters
+        };
+}

--- a/MoneyTrackerApplication.cs
+++ b/MoneyTrackerApplication.cs
@@ -5,8 +5,10 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MoneyTracker.Application.Services;
+using MoneyTracker.Application.Services.Interfaces;
 using MoneyTracker.Infrastructure.Database;
 using MoneyTracker.Infrastructure.DependencyInjection;
+using MoneyTracker.Infrastructure.Services;
 using MoneyTracker.Presentation.Services;
 using MoneyTracker.Presentation.Services.Interfaces;
 using System;
@@ -85,6 +87,9 @@ public class MoneyTrackerApplication : Android.App.Application
         services.AddSingleton<INavigationService>(sp => new AndroidNavigationService(sp.GetRequiredService<Func<Activity>>()));
         services.AddSingleton<ICacheService>(_ => new AndroidCacheService(ApplicationContext ?? throw new InvalidOperationException("ApplicationContext is not available")));
         services.AddSingleton<IMediaPickerService>(sp => new AndroidMediaPickerService(sp.GetRequiredService<Func<Activity>>()));
+        services.AddSingleton<ICommonQueryService, CommonQueryService>();
+        services.AddSingleton<ISettingsService, InMemorySettingsService>();
+        services.AddSingleton<IAcumaticaOptionsProvider, AcumaticaOptionsProvider>();
         // ViewModels
         services.AddTransient<MoneyTracker.Presentation.ViewModels.SettingsViewModel>();
         services.AddScoped<UserAppService>();

--- a/Presentation/Activities/SettingsActivity.cs
+++ b/Presentation/Activities/SettingsActivity.cs
@@ -1,34 +1,66 @@
+using System;
 using Android.App;
 using Android.OS;
 using Android.Widget;
 using MoneyTracker.Presentation.Base;
 using MoneyTracker.Presentation.ViewModels;
-using System;
 
-namespace MoneyTracker.Presentation.Activities
+namespace MoneyTracker.Presentation.Activities;
+
+[Activity(Label = "Settings")]
+public sealed class SettingsActivity : ActivityBase<SettingsViewModel>
 {
-    [Activity(Label = "Settings")]
-    public sealed class SettingsActivity : ActivityBase<SettingsViewModel>
+    protected override void OnCreate(Bundle? savedInstanceState)
     {
-        protected override void OnCreate(Bundle? savedInstanceState)
-        {
-            base.OnCreate(savedInstanceState);
-            SetContentView(Resource.Layout.activity_settings);
+        base.OnCreate(savedInstanceState);
+        SetContentView(Resource.Layout.activity_settings);
 
-            var txtUser = FindViewById<EditText>(Resource.Id.txtUserName)
-                ?? throw new InvalidOperationException("The user name field was not found in the layout.");
-            var btnSave = FindViewById<Button>(Resource.Id.btnSave)
-                ?? throw new InvalidOperationException("The save button was not found in the layout.");
+        var txtWarehouses = FindRequired<TextView>(Resource.Id.txtWarehousesList);
+        var editWarehouse = FindRequired<EditText>(Resource.Id.editSelectedWarehouse);
+        var chkShowZones = FindRequired<CheckBox>(Resource.Id.chkShowZones);
+        var txtZones = FindRequired<TextView>(Resource.Id.txtZonesList);
+        var editZone = FindRequired<EditText>(Resource.Id.editSelectedZone);
+        var txtReceivingBins = FindRequired<TextView>(Resource.Id.txtReceivingBinsList);
+        var editReceivingBin = FindRequired<EditText>(Resource.Id.editSelectedReceivingBin);
+        var txtShippingBins = FindRequired<TextView>(Resource.Id.txtShippingBinsList);
+        var editShippingBin = FindRequired<EditText>(Resource.Id.editSelectedShippingBin);
+        var chkShowPrinters = FindRequired<CheckBox>(Resource.Id.chkShowPrinters);
+        var txtPrinters = FindRequired<TextView>(Resource.Id.txtPrintersList);
+        var editPrinter = FindRequired<EditText>(Resource.Id.editSelectedPrinter);
+        var txtQuickCountTypes = FindRequired<TextView>(Resource.Id.txtQuickCountTypesList);
+        var editQuickCount = FindRequired<EditText>(Resource.Id.editSelectedQuickCountType);
+        var btnRefresh = FindRequired<Button>(Resource.Id.btnRefreshSettings);
+        var btnSave = FindRequired<Button>(Resource.Id.btnSaveSettings);
 
-            var set = CreateDataBindingSet();
+        var set = CreateDataBindingSet();
 
-            set.Bind(txtUser).To<string>(vm => ((SettingsViewModel)vm).UserName).TwoWay();
-            set.Bind(btnSave).To(vm => ((SettingsViewModel)vm).SaveCommand);
+        set.Bind(txtWarehouses).To<string>(vm => ((SettingsViewModel)vm).WarehousesSummary);
+        set.Bind(editWarehouse).To<string>(vm => ((SettingsViewModel)vm).SelectedWarehouseId).TwoWay();
+        set.Bind(chkShowZones).To<bool>(vm => ((SettingsViewModel)vm).ShowZones).TwoWay();
+        set.Bind(txtZones).To<string>(vm => ((SettingsViewModel)vm).ZonesSummary);
+        set.Bind(editZone).To<string>(vm => ((SettingsViewModel)vm).SelectedZone).TwoWay();
+        set.Bind(txtReceivingBins).To<string>(vm => ((SettingsViewModel)vm).ReceivingBinsSummary);
+        set.Bind(editReceivingBin).To<string>(vm => ((SettingsViewModel)vm).SelectedReceivingBin).TwoWay();
+        set.Bind(txtShippingBins).To<string>(vm => ((SettingsViewModel)vm).ShippingBinsSummary);
+        set.Bind(editShippingBin).To<string>(vm => ((SettingsViewModel)vm).SelectedShippingBin).TwoWay();
+        set.Bind(chkShowPrinters).To<bool>(vm => ((SettingsViewModel)vm).ShowPrinters).TwoWay();
+        set.Bind(txtPrinters).To<string>(vm => ((SettingsViewModel)vm).PrintersSummary);
+        set.Bind(editPrinter).To<string>(vm => ((SettingsViewModel)vm).SelectedPrinterName).TwoWay();
+        set.Bind(txtQuickCountTypes).To<string>(vm => ((SettingsViewModel)vm).QuickCountTypesSummary);
+        set.Bind(editQuickCount).To<string>(vm => ((SettingsViewModel)vm).SelectedQuickCountType).TwoWay();
 
-            set.Apply();
-            ApplyDataBindings();
+        set.Bind(btnRefresh).To(vm => ((SettingsViewModel)vm).DoRefreshCommand);
+        set.Bind(btnSave).To(vm => ((SettingsViewModel)vm).DoSaveCommand);
 
-            _ = ViewModel.LoadCommand.ExecuteAsync(null);
-        }
+        set.Apply();
+        ApplyDataBindings();
+
+        _ = ViewModel.DoLoadCommand.ExecuteAsync(null);
+    }
+
+    private TView FindRequired<TView>(int resourceId) where TView : class
+    {
+        return FindViewById(resourceId) as TView
+            ?? throw new InvalidOperationException($"The view with id {resourceId} was not found in the layout.");
     }
 }

--- a/Presentation/ViewModels/SettingsViewModel.cs
+++ b/Presentation/ViewModels/SettingsViewModel.cs
@@ -1,115 +1,242 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using MoneyTracker.Application.DTOs;
-using MoneyTracker.Application.Services;
+using MoneyTracker.Application.Services.Interfaces;
 using MoneyTracker.Presentation.Services.Interfaces;
-using System.Threading.Tasks;
 
 namespace MoneyTracker.Presentation.ViewModels;
 
 /// <summary>
-/// Settings ViewModel (persisted in the database through UserAppService).
-/// Follows the same pattern as TransactionListViewModel:
-/// - [ObservableProperty] on private fields with a leading underscore
-/// - [RelayCommand] for generated commands
+/// ViewModel that exposes configuration data for warehouse related settings.
 /// </summary>
 public partial class SettingsViewModel : BaseViewModel
 {
-    private readonly UserAppService _users;
-
-    // ===== Observable properties (same style: private fields with _) =====
-    [ObservableProperty]
-    private string _userName = string.Empty;
-
-    [ObservableProperty]
-    private string _preferredCurrency = "USD";
+    private readonly ICommonQueryService _commonQueryService;
+    private readonly ISettingsService _settingsService;
+    private readonly IAcumaticaOptionsProvider _optionsProvider;
+    private bool _suppressWarehouseSelection;
 
     [ObservableProperty]
-    private string _preferredDateFormat = "dd/MM/yyyy";
+    private ObservableCollection<string> _warehouseIds = new();
 
     [ObservableProperty]
-    private string _appTheme = "Light";
+    private ObservableCollection<string> _zones = new();
 
     [ObservableProperty]
-    private bool _notificationsEnabled = true;
+    private ObservableCollection<string> _receivingBins = new();
 
-    private int _userId;
+    [ObservableProperty]
+    private ObservableCollection<string> _shippingBins = new();
+
+    [ObservableProperty]
+    private ObservableCollection<string> _printersName = new();
+
+    [ObservableProperty]
+    private ObservableCollection<string> _quickCountTypes = new();
+
+    [ObservableProperty]
+    private string? _selectedWarehouseId;
+
+    [ObservableProperty]
+    private string? _selectedZone;
+
+    [ObservableProperty]
+    private string? _selectedReceivingBin;
+
+    [ObservableProperty]
+    private string? _selectedShippingBin;
+
+    [ObservableProperty]
+    private string? _selectedPrinterName;
+
+    [ObservableProperty]
+    private string? _selectedQuickCountType;
+
+    [ObservableProperty]
+    private bool _showZones;
+
+    [ObservableProperty]
+    private bool _showPrinters;
 
     public SettingsViewModel(
-        UserAppService users,
+        ICommonQueryService commonQueryService,
+        ISettingsService settingsService,
+        IAcumaticaOptionsProvider optionsProvider,
         IDialogService dialogService,
         INavigationService navigationService)
         : base(dialogService, navigationService)
     {
-        _users = users;
-        Title = "Settings";
-        // Initial load mimicking the TransactionListViewModel style
-        _ = LoadAsync();
+        _commonQueryService = commonQueryService;
+        _settingsService = settingsService;
+        _optionsProvider = optionsProvider;
+
+        Title = "Warehouse Settings";
     }
 
-    #region Commands
+    public string WarehousesSummary => FormatSummary(WarehouseIds);
 
-    /// <summary>
-    /// Loads user data from the database.
-    /// </summary>
+    public string ZonesSummary => FormatSummary(Zones);
+
+    public string ReceivingBinsSummary => FormatSummary(ReceivingBins);
+
+    public string ShippingBinsSummary => FormatSummary(ShippingBins);
+
+    public string PrintersSummary => FormatSummary(PrintersName);
+
+    public string QuickCountTypesSummary => FormatSummary(QuickCountTypes);
+
+    public bool HasZones => Zones.Count > 0;
+
+    public bool HasPrinters => PrintersName.Count > 0;
+
+    public bool HasQuickCountTypes => QuickCountTypes.Count > 0;
+
     [RelayCommand]
-    private async Task LoadAsync()
-    {
-        await ExecuteSafeAsync(async () =>
-        {
-            var dto = await _users.GetSettingsAsync();
-            if (dto is null) return;
+    private Task DoLoadAsync() => ExecuteSafeAsync(LoadInternalAsync);
 
-            _userId = dto.Id;
-            UserName = dto.Name ?? string.Empty;
-            PreferredCurrency = string.IsNullOrWhiteSpace(dto.Currency) ? "USD" : dto.Currency;
-            PreferredDateFormat = string.IsNullOrWhiteSpace(dto.DateFormat) ? "dd/MM/yyyy" : dto.DateFormat;
-            AppTheme = string.IsNullOrWhiteSpace(dto.Theme) ? "Light" : dto.Theme;
-            NotificationsEnabled = dto.ShowNotifications;
-        });
-    }
-
-    /// <summary>
-    /// Saves changes to the database.
-    /// </summary>
     [RelayCommand]
-    private async Task SaveAsync()
+    private Task DoRefreshAsync() => ExecuteSafeAsync(LoadInternalAsync);
+
+    [RelayCommand]
+    private Task DoSaveAsync() => ExecuteSafeAsync(SaveInternalAsync);
+
+    private async Task LoadInternalAsync()
     {
-        await ExecuteSafeAsync(async () =>
-        {
-            var name = (UserName ?? string.Empty).Trim();
-            if (name.Length == 0)
-            {
-                if (DialogService != null)
-                {
-                    await DialogService.ShowErrorAsync("Please enter a user name.");
-                }
-                return;
-            }
+        var warehouses = await _commonQueryService.GetWarehouseIdsAsync().ConfigureAwait(false);
+        WarehouseIds = new ObservableCollection<string>(warehouses);
+        OnPropertyChanged(nameof(WarehousesSummary));
 
-            var dto = new UserSettingsDto
-            {
-                Id = _userId,
-                Name = name,
-                Currency = (PreferredCurrency ?? "USD").Trim().ToUpperInvariant(),
-                DateFormat = string.IsNullOrWhiteSpace(PreferredDateFormat) ? "dd/MM/yyyy" : PreferredDateFormat.Trim(),
-                Theme = string.IsNullOrWhiteSpace(AppTheme) ? "Light" : AppTheme.Trim(),
-                ShowNotifications = NotificationsEnabled
-            };
+        var printers = await _commonQueryService.GetPrintersAsync().ConfigureAwait(false);
+        PrintersName = new ObservableCollection<string>(printers);
+        OnPropertyChanged(nameof(PrintersSummary));
+        OnPropertyChanged(nameof(HasPrinters));
 
-            var (success, error) = await _users.UpdateSettingsAsync(dto);
-            if (!success)
-            {
-                if (DialogService != null)
-                {
-                    await DialogService.ShowErrorAsync(error ?? "The settings could not be saved.");
-                }
-                return;
-            }
+        var quickCountTypes = _optionsProvider.GetQuickCountTypes();
+        QuickCountTypes = new ObservableCollection<string>(quickCountTypes);
+        OnPropertyChanged(nameof(QuickCountTypesSummary));
+        OnPropertyChanged(nameof(HasQuickCountTypes));
 
-            DialogService?.ShowToast("Settings saved.");
-        });
+        var dto = await _settingsService.GetWarehouseSettingsAsync().ConfigureAwait(false);
+
+        _suppressWarehouseSelection = true;
+        SelectedWarehouseId = !string.IsNullOrWhiteSpace(dto?.WarehouseId)
+            ? dto!.WarehouseId
+            : WarehouseIds.FirstOrDefault();
+        SelectedZone = dto?.Zone;
+        SelectedReceivingBin = dto?.ReceivingBin;
+        SelectedShippingBin = dto?.ShippingBin;
+        SelectedPrinterName = !string.IsNullOrWhiteSpace(dto?.PrinterName)
+            ? dto!.PrinterName
+            : PrintersName.FirstOrDefault();
+        SelectedQuickCountType = !string.IsNullOrWhiteSpace(dto?.QuickCountType)
+            ? dto!.QuickCountType
+            : QuickCountTypes.FirstOrDefault();
+        ShowZones = dto?.ShowZones ?? _optionsProvider.ShouldShowZones(SelectedWarehouseId ?? string.Empty);
+        ShowPrinters = dto?.ShowPrinters ?? _optionsProvider.ShouldShowPrinters();
+        _suppressWarehouseSelection = false;
+
+        await SetWarehouse(SelectedWarehouseId).ConfigureAwait(false);
     }
 
-    #endregion
+    private async Task SaveInternalAsync()
+    {
+        var warehouseId = SelectedWarehouseId?.Trim();
+        if (string.IsNullOrWhiteSpace(warehouseId))
+        {
+            if (DialogService != null)
+            {
+                await DialogService.ShowErrorAsync("Please provide a warehouse identifier.").ConfigureAwait(false);
+            }
+            return;
+        }
+
+        var settings = new WarehouseSettingsDto
+        {
+            WarehouseId = warehouseId,
+            Zone = string.IsNullOrWhiteSpace(SelectedZone) ? null : SelectedZone!.Trim(),
+            ReceivingBin = string.IsNullOrWhiteSpace(SelectedReceivingBin) ? null : SelectedReceivingBin!.Trim(),
+            ShippingBin = string.IsNullOrWhiteSpace(SelectedShippingBin) ? null : SelectedShippingBin!.Trim(),
+            PrinterName = string.IsNullOrWhiteSpace(SelectedPrinterName) ? null : SelectedPrinterName!.Trim(),
+            QuickCountType = string.IsNullOrWhiteSpace(SelectedQuickCountType)
+                ? QuickCountTypes.FirstOrDefault()
+                : SelectedQuickCountType!.Trim(),
+            ShowZones = ShowZones && HasZones,
+            ShowPrinters = ShowPrinters && HasPrinters
+        };
+
+        await _settingsService.SaveWarehouseSettingsAsync(settings).ConfigureAwait(false);
+        DialogService?.ShowToast("Settings saved successfully.");
+    }
+
+    private async Task SetWarehouse(string? warehouseId)
+    {
+        var metadataId = string.IsNullOrWhiteSpace(warehouseId)
+            ? null
+            : warehouseId!.Trim();
+
+        var zones = metadataId == null
+            ? Array.Empty<string>()
+            : await _commonQueryService.GetZonesAsync(metadataId).ConfigureAwait(false);
+        Zones = new ObservableCollection<string>(zones);
+        OnPropertyChanged(nameof(ZonesSummary));
+        OnPropertyChanged(nameof(HasZones));
+
+        var receivingBins = metadataId == null
+            ? Array.Empty<string>()
+            : await _commonQueryService.GetReceivingBinsAsync(metadataId).ConfigureAwait(false);
+        ReceivingBins = new ObservableCollection<string>(receivingBins);
+        OnPropertyChanged(nameof(ReceivingBinsSummary));
+
+        var shippingBins = metadataId == null
+            ? Array.Empty<string>()
+            : await _commonQueryService.GetShippingBinsAsync(metadataId).ConfigureAwait(false);
+        ShippingBins = new ObservableCollection<string>(shippingBins);
+        OnPropertyChanged(nameof(ShippingBinsSummary));
+
+        if (!Zones.Contains(SelectedZone ?? string.Empty))
+        {
+            SelectedZone = Zones.FirstOrDefault();
+        }
+
+        if (!ReceivingBins.Contains(SelectedReceivingBin ?? string.Empty))
+        {
+            SelectedReceivingBin = ReceivingBins.FirstOrDefault();
+        }
+
+        if (!ShippingBins.Contains(SelectedShippingBin ?? string.Empty))
+        {
+            SelectedShippingBin = ShippingBins.FirstOrDefault();
+        }
+
+        if (metadataId != null)
+        {
+            ShowZones = ShowZones || _optionsProvider.ShouldShowZones(metadataId);
+        }
+
+        OnPropertyChanged(nameof(ShowZones));
+    }
+
+    partial void OnSelectedWarehouseIdChanged(string? value)
+    {
+        if (_suppressWarehouseSelection)
+        {
+            return;
+        }
+
+        _ = ExecuteSafeAsync(() => SetWarehouse(value), nameof(SetWarehouse));
+    }
+
+    private static string FormatSummary(ObservableCollection<string> values)
+    {
+        return values.Count switch
+        {
+            0 => "No data available",
+            1 => values[0],
+            _ => string.Join(", ", values)
+        };
+    }
 }

--- a/Resources/layout/activity_settings.xml
+++ b/Resources/layout/activity_settings.xml
@@ -1,24 +1,150 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:padding="16dp"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="User name" />
-
-    <EditText
-        android:id="@+id/txtUserName"
+    <LinearLayout
+        android:orientation="vertical"
+        android:padding="16dp"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="Enter your name" />
+        android:layout_height="wrap_content">
 
-    <Button
-        android:id="@+id/btnSave"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Save" />
-</LinearLayout>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Available warehouses" />
+
+        <TextView
+            android:id="@+id/txtWarehousesList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:textStyle="bold" />
+
+        <EditText
+            android:id="@+id/editSelectedWarehouse"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Selected warehouse" />
+
+        <CheckBox
+            android:id="@+id/chkShowZones"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Show zones" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Zones" />
+
+        <TextView
+            android:id="@+id/txtZonesList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp" />
+
+        <EditText
+            android:id="@+id/editSelectedZone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Selected zone" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Receiving bins" />
+
+        <TextView
+            android:id="@+id/txtReceivingBinsList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp" />
+
+        <EditText
+            android:id="@+id/editSelectedReceivingBin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Selected receiving bin" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Shipping bins" />
+
+        <TextView
+            android:id="@+id/txtShippingBinsList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp" />
+
+        <EditText
+            android:id="@+id/editSelectedShippingBin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Selected shipping bin" />
+
+        <CheckBox
+            android:id="@+id/chkShowPrinters"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Show printers" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Printers" />
+
+        <TextView
+            android:id="@+id/txtPrintersList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp" />
+
+        <EditText
+            android:id="@+id/editSelectedPrinter"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Selected printer" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Quick count types" />
+
+        <TextView
+            android:id="@+id/txtQuickCountTypesList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp" />
+
+        <EditText
+            android:id="@+id/editSelectedQuickCountType"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Selected quick count type" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/btnRefreshSettings"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Refresh" />
+
+            <Button
+                android:id="@+id/btnSaveSettings"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:text="Save" />
+        </LinearLayout>
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Summary
- add service interfaces and in-memory implementations for warehouse lookups, settings storage, and quick count options and register them in the application startup
- refactor `SettingsViewModel` to expose warehouse, bin, printer, and quick-count observable properties with RelayCommands using `ExecuteSafeAsync` and a centralized `SetWarehouse` helper
- update the settings activity layout and bindings to work with the new properties and commands

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc6a2f3e48832d8bd38bcedf2b3938